### PR TITLE
Add FAB and Font Awesome links to pages

### DIFF
--- a/business.html
+++ b/business.html
@@ -5,6 +5,8 @@
   <title>Business Operations • OPS</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="global.css">
+  <link rel="stylesheet" href="fabs.css">
+  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
 </head>
 <body>
   <nav class="ops-nav">

--- a/contactcenter.html
+++ b/contactcenter.html
@@ -5,6 +5,8 @@
   <title>Contact Center • OPS</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="global.css">
+  <link rel="stylesheet" href="fabs.css">
+  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
 </head>
 <body>
   <nav class="ops-nav">

--- a/itsupport.html
+++ b/itsupport.html
@@ -5,6 +5,8 @@
   <title>IT Support • OPS</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="global.css">
+  <link rel="stylesheet" href="fabs.css">
+  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
 </head>
 <body>
   <nav class="ops-nav">

--- a/professionals.html
+++ b/professionals.html
@@ -5,6 +5,8 @@
   <title>Professionals • OPS</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="global.css">
+  <link rel="stylesheet" href="fabs.css">
+  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
 </head>
 <body>
   <nav class="ops-nav">


### PR DESCRIPTION
## Summary
- include `fabs.css` and Font Awesome styles on Business Ops, Contact Center, IT Support and Professionals pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a3d0a19e8832bb3db2df80bb3570a