### PR TITLE
Add cancel button and backdrop style

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -79,5 +79,10 @@ async function fetchContent(url) {
       closeModal();
     }
   };
+  if (type === 'contact') {
+    modalOverlay.style.background = 'transparent';
+    const cancel = modalOverlay.querySelector('#cancel-btn');
+    if (cancel) cancel.onclick = closeModal;
+  }
   document.addEventListener('keydown', handleEsc);
 }

--- a/contact/contact.html
+++ b/contact/contact.html
@@ -208,6 +208,7 @@
     <div class="modal-footer">
       <button type="submit" form="contact-form" class="submit-button"
               data-en="Send" data-es="Enviar">Send</button>
+      <button id="cancel-btn" class="submit-button" type="button">Cancel</button>
     </div>
 
   </div>


### PR DESCRIPTION
## Summary
- add Cancel button to contact form modal
- make contact modal backdrop transparent and close with Cancel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b92879558832ba00c7672f3b36005