### PR TITLE
Fix join page missing FAB loader

### DIFF
--- a/join.html
+++ b/join.html
@@ -7,11 +7,13 @@
   <link rel="stylesheet" href="global.css">
   <link rel="stylesheet" href="fabs.css">
 </head>
-<body>
-  <script type="module">
-    import { openModal } from './connector.js';
-    window.addEventListener('DOMContentLoaded', () => openModal('join'));
-  </script>
-  <script type="module" src="bot.js"></script>
-</body>
+  <body>
+    <script type="module">
+      import { openModal } from './connector.js';
+      window.addEventListener('DOMContentLoaded', () => openModal('join'));
+    </script>
+    <div id="fab-root"></div>
+    <script type="module" src="fabmain.js"></script>
+    <script type="module" src="bot.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add FAB container div on the Join page
- include `fabmain.js` on the Join page for consistent FAB buttons

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ba0209df4832b8c01e83c4c419b82