### PR TITLE
Refactor language/theme toggles

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -41,39 +41,17 @@ export function openChatbot() {
   centerModal(chatbotContainer);
 
 
-  const qs=s=>document.querySelector(s),
-        qsa=s=>[...document.querySelectorAll(s)];
+  const qs=s=>document.querySelector(s);
 
   /* === Language toggle === */
-  const langCtrl   = qs('#langCtrl'),
-        transNodes = qsa('[data-en]'),
-        phNodes    = qsa('[data-en-ph]'),
-        humanLab   = qs('#human-label');
-
-  langCtrl.onclick = () => {
-    const toES = langCtrl.textContent === 'ES';      // going EN→ES ?
-    document.documentElement.lang = toES ? 'es' : 'en';
-    langCtrl.textContent = toES ? 'EN' : 'ES';
-
-    // text nodes
-    transNodes.forEach(node => {
-        if (node.dataset.es && node.dataset.en) {
-            node.textContent = toES ? node.dataset.es : node.dataset.en
-        }
-    });
-
-    // placeholders
-    phNodes.forEach(node => node.placeholder  = toES ? node.dataset.esPh : node.dataset.enPh);
-    humanLab.textContent = toES ? humanLab.dataset.es : humanLab.dataset.en;
-  };
+  const langCtrl = qs('#langCtrl');
+  if (langCtrl) langCtrl.onclick = () =>
+    window.dispatchEvent(new Event('toggle-lang'));
 
   /* === Theme toggle === */
   const themeCtrl = qs('#themeCtrl');
-  themeCtrl.onclick = () => {
-    const dark = themeCtrl.textContent === 'Dark';
-    document.body.classList.toggle('dark', dark);
-    themeCtrl.textContent = dark ? 'Light' : 'Dark';
-  };
+  if (themeCtrl) themeCtrl.onclick = () =>
+    window.dispatchEvent(new Event('toggle-theme'));
 
   /* === Chatbot core === */
   const log   = qs('#chat-log'),

--- a/central.js
+++ b/central.js
@@ -1,5 +1,41 @@
 // central.js
-document.addEventListener('DOMContentLoaded', () => {
-  // This file is now empty of chatbot logic.
-});
 
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.documentElement;
+
+  function applyLanguage(toES) {
+    root.lang = toES ? 'es' : 'en';
+    document.querySelectorAll('#lang-toggle,#mobile-lang-toggle,#langCtrl').forEach(btn => {
+      if (btn) btn.textContent = toES ? 'EN' : 'ES';
+    });
+    document.querySelectorAll('[data-en]').forEach(el => {
+      if (el.dataset.en && el.dataset.es) {
+        el.textContent = toES ? el.dataset.es : el.dataset.en;
+      }
+    });
+    document.querySelectorAll('[data-en-ph]').forEach(el => {
+      el.placeholder = toES ? el.dataset.esPh : el.dataset.enPh;
+    });
+  }
+
+  function applyTheme(dark) {
+    document.body.classList.toggle('dark', dark);
+    document.querySelectorAll('#theme-toggle,#mobile-theme-toggle,#themeCtrl').forEach(btn => {
+      if (btn) btn.textContent = dark ? 'Light' : 'Dark';
+    });
+  }
+
+  window.addEventListener('toggle-lang', () => {
+    const toES = root.lang === 'en';
+    applyLanguage(toES);
+  });
+
+  window.addEventListener('toggle-theme', () => {
+    const dark = !document.body.classList.contains('dark');
+    applyTheme(dark);
+  });
+
+  // initialize based on current DOM state
+  applyLanguage(root.lang === 'es');
+  applyTheme(document.body.classList.contains('dark'));
+});

--- a/index.html
+++ b/index.html
@@ -15,10 +15,10 @@
   <nav class="ops-nav">
     <span class="ops-logo">OPS</span>
     <div class="nav-links">
-      <a href="business.html" class="nav-link" data-lang-en="Business Operations" data-lang-es="Operaciones de Negocio">Business Operations</a>
-      <a href="contactcenter.html" class="nav-link" data-lang-en="Contact Center" data-lang-es="Centro de Contacto">Contact Center</a>
-      <a href="itsupport.html" class="nav-link" data-lang-en="IT Support" data-lang-es="Soporte de TI">IT Support</a>
-      <a href="professionals.html" class="nav-link" data-lang-en="Professionals" data-lang-es="Profesionales">Professionals</a>
+      <a href="business.html" class="nav-link" data-en="Business Operations" data-es="Operaciones de Negocio">Business Operations</a>
+      <a href="contactcenter.html" class="nav-link" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</a>
+      <a href="itsupport.html" class="nav-link" data-en="IT Support" data-es="Soporte de TI">IT Support</a>
+      <a href="professionals.html" class="nav-link" data-en="Professionals" data-es="Profesionales">Professionals</a>
     </div>
     <div class="toggles">
       <button class="toggle-btn" id="lang-toggle">EN</button>
@@ -30,31 +30,31 @@
   <main>
     <div class="grid-container">
       <div class="card" id="card-business">
-        <div class="title" data-lang-en="Business Operations" data-lang-es="Operaciones de Negocio">Business Operations</div>
+        <div class="title" data-en="Business Operations" data-es="Operaciones de Negocio">Business Operations</div>
         <div class="icon"><i class="fa-thin fa-briefcase"></i></div>
         <div class="content">
-          <p data-lang-en="Streamline your processes, maximize efficiency, ensure compliance, and scale your business with precision." data-lang-es="Optimice sus procesos, maximice la eficiencia, garantice el cumplimiento y escale su negocio con precisión.">Streamline your processes, maximize efficiency, ensure compliance, and scale your business with precision.</p>
+          <p data-en="Streamline your processes, maximize efficiency, ensure compliance, and scale your business with precision." data-es="Optimice sus procesos, maximice la eficiencia, garantice el cumplimiento y escale su negocio con precisión.">Streamline your processes, maximize efficiency, ensure compliance, and scale your business with precision.</p>
         </div>
       </div>
       <div class="card" id="card-contactcenter">
-        <div class="title" data-lang-en="Contact Center" data-lang-es="Centro de Contacto">Contact Center</div>
+        <div class="title" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</div>
         <div class="icon"><i class="fa-thin fa-headset"></i></div>
         <div class="content">
-          <p data-lang-en="Enhance customer engagement with multilingual, multichannel support—24/7, data-driven, and empathetic." data-lang-es="Mejore la participación del cliente con soporte multilingüe y multicanal: 24/7, basado en datos y empático.">Enhance customer engagement with multilingual, multichannel support—24/7, data-driven, and empathetic.</p>
+          <p data-en="Enhance customer engagement with multilingual, multichannel support—24/7, data-driven, and empathetic." data-es="Mejore la participación del cliente con soporte multilingüe y multicanal: 24/7, basado en datos y empático.">Enhance customer engagement with multilingual, multichannel support—24/7, data-driven, and empathetic.</p>
         </div>
       </div>
       <div class="card" id="card-itsupport">
-        <div class="title" data-lang-en="IT Support" data-lang-es="Soporte de TI">IT Support</div>
+        <div class="title" data-en="IT Support" data-es="Soporte de TI">IT Support</div>
         <div class="icon"><i class="fa-thin fa-laptop-code"></i></div>
         <div class="content">
-          <p data-lang-en="Proactive, secure, real-time tech help, cloud management, and cyber defense for every business size." data-lang-es="Ayuda técnica proactiva, segura y en tiempo real, gestión de la nube y ciberdefensa para empresas de todos los tamaños.">Proactive, secure, real-time tech help, cloud management, and cyber defense for every business size.</p>
+          <p data-en="Proactive, secure, real-time tech help, cloud management, and cyber defense for every business size." data-es="Ayuda técnica proactiva, segura y en tiempo real, gestión de la nube y ciberdefensa para empresas de todos los tamaños.">Proactive, secure, real-time tech help, cloud management, and cyber defense for every business size.</p>
         </div>
       </div>
       <div class="card" id="card-professionals">
-        <div class="title" data-lang-en="Professionals" data-lang-es="Profesionales">Professionals</div>
+        <div class="title" data-en="Professionals" data-es="Profesionales">Professionals</div>
         <div class="icon"><i class="fa-thin fa-user-tie"></i></div>
         <div class="content">
-          <p data-lang-en="OPS-vetted talent for IT, HR, projects, finance—contract or full-time, ready when you are." data-lang-es="Talento investigado por OPS para TI, recursos humanos, proyectos, finanzas, por contrato o a tiempo completo, listo cuando usted lo esté.">OPS-vetted talent for IT, HR, projects, finance—contract or full-time, ready when you are.</p>
+          <p data-en="OPS-vetted talent for IT, HR, projects, finance—contract or full-time, ready when you are." data-es="Talento investigado por OPS para TI, recursos humanos, proyectos, finanzas, por contrato o a tiempo completo, listo cuando usted lo esté.">OPS-vetted talent for IT, HR, projects, finance—contract or full-time, ready when you are.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- centralize language and theme logic in `central.js`
- dispatch toggle events from chatbot
- standardize translation attributes on the home page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687bae10494c832b9eabf98ad361a14b