### PR TITLE
Center page content

### DIFF
--- a/business-modal.html
+++ b/business-modal.html
@@ -3,7 +3,7 @@
   <div class="modal-header">
     <h3 data-en="Business Operations" data-es="Operaciones de Negocio">Business Operations</h3>
   </div>
-  <div class="modal-body">
+  <div class="modal-body centered">
   <img src="https://via.placeholder.com/700x300" alt="Image placeholder" style="width:100%; height:auto;">
   <p>
     Optimize, secure, and scale your core processes with OPS Business Operations.<br>

--- a/business.html
+++ b/business.html
@@ -26,7 +26,7 @@
       <button role="button" class="toggle-btn" id="theme-toggle">Dark</button>
     </div>
   </nav>
-  <main style="max-width:700px; margin:3em auto;">
+  <main class="centered" style="max-width:700px; margin:3em auto;">
     <h1 style="text-transform:uppercase;">Business Operations</h1>
     <img src="https://via.placeholder.com/700x300" alt="Image placeholder" style="width:100%; height:auto;">
     <p>

--- a/contactcenter-modal.html
+++ b/contactcenter-modal.html
@@ -3,7 +3,7 @@
   <div class="modal-header">
     <h3 data-en="Contact Center" data-es="Centro de Contacto">Contact Center</h3>
   </div>
-  <div class="modal-body">
+  <div class="modal-body centered">
     <img src="https://via.placeholder.com/700x300" alt="Image placeholder" style="width:100%; height:auto;">
     <p>
         Enhance customer engagement with our comprehensive Contact Center solutions.

--- a/contactcenter.html
+++ b/contactcenter.html
@@ -26,7 +26,7 @@
       <button role="button" class="toggle-btn" id="theme-toggle">Dark</button>
     </div>
   </nav>
-  <main style="max-width:700px; margin:3em auto;">
+  <main class="centered" style="max-width:700px; margin:3em auto;">
     <h1 style="text-transform:uppercase;">Contact Center</h1>
     <img src="https://via.placeholder.com/700x300" alt="Image placeholder" style="width:100%; height:auto;">
     <p>

--- a/global.css
+++ b/global.css
@@ -19,6 +19,11 @@ body.dark {
   color: #fafbfe;
 }
 
+/* Utility class for centered text */
+.centered {
+  text-align: center;
+}
+
 /* Modal drag styles */
 .ops-modal.dragging {
   opacity: 0.95;

--- a/itsupport-modal.html
+++ b/itsupport-modal.html
@@ -3,7 +3,7 @@
   <div class="modal-header">
     <h3 data-en="IT Support" data-es="Soporte de TI">IT Support</h3>
   </div>
-  <div class="modal-body">
+  <div class="modal-body centered">
     <img src="https://via.placeholder.com/700x300" alt="Image placeholder" style="width:100%; height:auto;">
     <p>
         Reliable and timely IT support to keep your systems running smoothly.

--- a/itsupport.html
+++ b/itsupport.html
@@ -26,7 +26,7 @@
       <button role="button" class="toggle-btn" id="theme-toggle">Dark</button>
     </div>
   </nav>
-  <main style="max-width:700px; margin:3em auto;">
+  <main class="centered" style="max-width:700px; margin:3em auto;">
     <h1 style="text-transform:uppercase;">IT Support</h1>
     <img src="https://via.placeholder.com/700x300" alt="Image placeholder" style="width:100%; height:auto;">
     <p>

--- a/professionals-modal.html
+++ b/professionals-modal.html
@@ -3,7 +3,7 @@
   <div class="modal-header">
     <h3 data-en="Professionals" data-es="Profesionales">Professionals</h3>
   </div>
-  <div class="modal-body">
+  <div class="modal-body centered">
     <img src="https://via.placeholder.com/700x300" alt="Image placeholder" style="width:100%; height:auto;">
     <p>
         Access our network of highly skilled and experienced professionals.

--- a/professionals.html
+++ b/professionals.html
@@ -26,7 +26,7 @@
       <button role="button" class="toggle-btn" id="theme-toggle">Dark</button>
     </div>
   </nav>
-  <main style="max-width:700px; margin:3em auto;">
+  <main class="centered" style="max-width:700px; margin:3em auto;">
     <h1 style="text-transform:uppercase;">Professionals</h1>
     <img src="https://via.placeholder.com/700x300" alt="Image placeholder" style="width:100%; height:auto;">
     <p>


### PR DESCRIPTION
## Summary
- add a `centered` utility class in global.css
- center the main body of Business Operations, Contact Center, IT Support, and Professionals pages
- center the body of related modals

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687bc4be2320832b88d767426c397f50