### PR TITLE
fix: Relax Content-Security-Policy and update stylesheet links

### DIFF
--- a/business.html
+++ b/business.html
@@ -6,11 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="OPS Business Operations services and optimization">
   <meta name="robots" content="index, follow">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-elem 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' https://via.placeholder.com; media-src 'self' https://www.w3schools.com;">
   <link rel="stylesheet" href="global.css">
   <link rel="stylesheet" href="fabs.css">
   <link rel="stylesheet" href="bot.css">
-  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta1/css/all.min.css">
 </head>
 <body>
   <nav class="ops-nav">

--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
   <title>Contact Modal</title>
   <meta name="description" content="Contact form modal for OPS">
   <meta name="robots" content="index, follow">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-elem 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' https://via.placeholder.com; media-src 'self' https://www.w3schools.com;">
   <style>
     /* === Modal Base === */
     .modal-overlay {

--- a/contactcenter.html
+++ b/contactcenter.html
@@ -6,11 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="OPS Contact Center solutions">
   <meta name="robots" content="index, follow">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-elem 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' https://via.placeholder.com; media-src 'self' https://www.w3schools.com;">
   <link rel="stylesheet" href="global.css">
   <link rel="stylesheet" href="fabs.css">
   <link rel="stylesheet" href="bot.css">
-  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta1/css/all.min.css">
 </head>
 <body>
   <nav class="ops-nav">

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="OPS Online Support structure prototype and navigation">
   <meta name="robots" content="index, follow">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-elem 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' https://via.placeholder.com; media-src 'self' https://www.w3schools.com;">
   <link rel="stylesheet" href="global.css">
   <link rel="stylesheet" href="fabs.css">
   <link rel="stylesheet" href="bot.css">
   <!-- Font Awesome Pro 6 -->
-  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta1/css/all.min.css">
 </head>
 <body>
   <!-- NAVIGATION -->

--- a/itsupport.html
+++ b/itsupport.html
@@ -6,11 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="OPS IT Support services">
   <meta name="robots" content="index, follow">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-elem 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' https://via.placeholder.com; media-src 'self' https://www.w3schools.com;">
   <link rel="stylesheet" href="global.css">
   <link rel="stylesheet" href="fabs.css">
   <link rel="stylesheet" href="bot.css">
-  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta1/css/all.min.css">
 </head>
 <body>
   <nav class="ops-nav">

--- a/join.html
+++ b/join.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Join OPS to collaborate or sign up">
   <meta name="robots" content="index, follow">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-elem 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' https://via.placeholder.com; media-src 'self' https://www.w3schools.com;">
   <link rel="stylesheet" href="global.css">
   <link rel="stylesheet" href="fabs.css">
 </head>

--- a/professionals.html
+++ b/professionals.html
@@ -6,11 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="OPS professionals network and services">
   <meta name="robots" content="index, follow">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' unsafe-inline; style-src 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; style-src-elem 'self' unsafe-inline https://cdnjs.cloudflare.com https://fonts.googleapis.com; img-src 'self' https://via.placeholder.com; media-src 'self' https://www.w3schools.com;">
   <link rel="stylesheet" href="global.css">
   <link rel="stylesheet" href="fabs.css">
   <link rel="stylesheet" href="bot.css">
-  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v6.0.0-beta1/css/all.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta1/css/all.min.css">
 </head>
 <body>
   <nav class="ops-nav">


### PR DESCRIPTION
The previous CSP was too restrictive and blocked resources from:
- pro.fontawesome.com (stylesheets)
- via.placeholder.com (images)
- www.w3schools.com (media)

This change updates the CSP in all HTML files to allow these resources to be loaded. It also updates the Font Awesome stylesheet to use the Cloudflare CDN.