### PR TITLE
Enable modal actions on service pages

### DIFF
--- a/js/connector.js
+++ b/js/connector.js
@@ -83,7 +83,11 @@ function showFormModal(type) {
           </form>
         </div>`;
     document.getElementById('modal-root').appendChild(m);
-    const closeForm = () => m.remove();
+    const fromService = window.location.pathname.includes('/pages/');
+    const closeForm = () => {
+        m.remove();
+        if (fromService) window.location.href = '../index.html';
+    };
     m.querySelector('.modal-close').onclick = closeForm;
     m.onclick = e => { if (e.target === m) closeForm(); };
 }

--- a/pages/business.html
+++ b/pages/business.html
@@ -57,11 +57,12 @@
  	 Content Here
     </p>
     <div class="modal-actions" style="margin-top:2.2em;">
-      <a href="contact.html" class="modal-btn cta">Contact Us</a>
-      <a href="join.html" class="modal-btn">Join Us</a>
+      <a href="#" class="modal-btn cta" onclick="openContactModal();return false;">Contact Us</a>
+      <a href="#" class="modal-btn" onclick="openJoinModal();return false;">Join Us</a>
     </div>
   </main>
   <div id="fab-root"></div>
+  <div id="modal-root"></div>
   <footer>© 2025 OPS Online Support</footer>
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../js/connector.js"></script>

--- a/pages/contactcenter.html
+++ b/pages/contactcenter.html
@@ -56,11 +56,12 @@
  	 Content Here
     </p>
     <div class="modal-actions" style="margin-top:2.2em;">
-      <a href="contact.html" class="modal-btn cta">Contact Us</a>
-      <a href="join.html" class="modal-btn">Join Us</a>
+      <a href="#" class="modal-btn cta" onclick="openContactModal();return false;">Contact Us</a>
+      <a href="#" class="modal-btn" onclick="openJoinModal();return false;">Join Us</a>
     </div>
   </main>
   <div id="fab-root"></div>
+  <div id="modal-root"></div>
   <footer>© 2025 OPS Online Support</footer>
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../js/connector.js"></script>

--- a/pages/itsupport.html
+++ b/pages/itsupport.html
@@ -56,11 +56,12 @@ Content Here
 Content Here
     </p>
     <div class="modal-actions" style="margin-top:2.2em;">
-      <a href="contact.html" class="modal-btn cta">Contact Us</a>
-      <a href="join.html" class="modal-btn">Join Us</a>
+      <a href="#" class="modal-btn cta" onclick="openContactModal();return false;">Contact Us</a>
+      <a href="#" class="modal-btn" onclick="openJoinModal();return false;">Join Us</a>
     </div>
   </main>
   <div id="fab-root"></div>
+  <div id="modal-root"></div>
   <footer>© 2025 OPS Online Support</footer>
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../js/connector.js"></script>

--- a/pages/professionals.html
+++ b/pages/professionals.html
@@ -56,11 +56,12 @@
  	 Content Here
     </p>
     <div class="modal-actions" style="margin-top:2.2em;">
-      <a href="contact.html" class="modal-btn cta">Contact Us</a>
-      <a href="join.html" class="modal-btn">Join Us</a>
+      <a href="#" class="modal-btn cta" onclick="openContactModal();return false;">Contact Us</a>
+      <a href="#" class="modal-btn" onclick="openJoinModal();return false;">Join Us</a>
     </div>
   </main>
   <div id="fab-root"></div>
+  <div id="modal-root"></div>
   <footer>© 2025 OPS Online Support</footer>
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../js/connector.js"></script>


### PR DESCRIPTION
## Summary
- launch contact/join modals directly on service pages
- redirect back to `index.html` when closing the modal from a service page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d5bd9cf50832b8c121c11c9dfabe2