### PR TITLE
Add close button to chatbot

### DIFF
--- a/chattia.html
+++ b/chattia.html
@@ -29,6 +29,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   background:linear-gradient(135deg,var(--clr-primary) 0%,var(--clr-accent) 100%);
   color:#fff;font-weight:600;font-size:1.1rem;padding:.75rem 1rem}
 #chatbot-header .ctrl{cursor:pointer;font-size:.75rem;font-weight:500;user-select:none;opacity:.85}
+#chatbot-header button.ctrl{background:transparent;border:none;color:inherit;padding:0}
 #chatbot-header .ctrl:hover{opacity:1}
 #chat-log{flex:1;overflow-y:auto;padding:1rem;background:#1b0e2d;color:#eee;font-size:.94rem}
 .chat-msg{margin:.5rem 0;max-width:90%}
@@ -59,6 +60,8 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
       <span id="langCtrl" class="ctrl">ES</span>
       &nbsp;|&nbsp;
       <span id="themeCtrl" class="ctrl">Dark</span>
+      &nbsp;|&nbsp;
+      <button id="closeCtrl" class="ctrl" aria-label="Close">&times;</button>
     </div>
   </div>
 
@@ -88,7 +91,8 @@ const qs=s=>document.querySelector(s),
 const langCtrl   = qs('#langCtrl'),
       transNodes = qsa('[data-en]'),
       phNodes    = qsa('[data-en-ph]'),
-      humanLab   = qs('#human-label');
+      humanLab   = qs('#human-label'),
+      closeCtrl  = qs('#closeCtrl');
 
 langCtrl.onclick = () => {
   const toES = langCtrl.textContent === 'ES';      // going EN→ES ?
@@ -102,6 +106,14 @@ langCtrl.onclick = () => {
   phNodes.forEach(node => node.placeholder  = toES ? node.dataset.esPh : node.dataset.enPh);
   humanLab.textContent = toES ? humanLab.dataset.es : humanLab.dataset.en;
 };
+
+/* === Close handler === */
+function closeChat(){
+  if(history.length>1) history.back();
+  else location.href='index.html';
+}
+closeCtrl.onclick = closeChat;
+document.addEventListener('keydown',e=>{if(e.key==='Escape') closeChat();});
 
 /* === Theme toggle === */
 const themeCtrl = qs('#themeCtrl');


### PR DESCRIPTION
## Summary
- add visible close button in the chatbot header
- style button for seamless look
- implement handler to return to previous page or `index.html`
- enable ESC key to close the chatbot

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d8b111480832bbe658995cf5aeefd