### PR TITLE
Run sanitizeForms after modal append

### DIFF
--- a/js/connector.js
+++ b/js/connector.js
@@ -1,5 +1,6 @@
 import { makeModalDraggable } from './bot.js';
 import { services } from '../app-data.js';
+import { sanitizeForms } from './security.js';
 
 let lang = 'en';
 
@@ -83,6 +84,7 @@ function showFormModal(type) {
           </form>
         </div>`;
     document.getElementById('modal-root').appendChild(m);
+    sanitizeForms(m.querySelector('form'));
     const fromService = window.location.pathname.includes('/pages/');
     const closeForm = () => {
         m.remove();

--- a/js/security.js
+++ b/js/security.js
@@ -53,10 +53,20 @@ export function sanitize(dirty) {
 /**
  * Sanitize all form inputs on the page.
  */
-export function sanitizeForms() {
-  const forms = document.querySelectorAll('form');
+export function sanitizeForms(target = document) {
+  let forms;
+  if (target instanceof HTMLFormElement) {
+    forms = [target];
+  } else if (target && typeof target.querySelectorAll === 'function') {
+    forms = target.querySelectorAll('form');
+  } else {
+    forms = document.querySelectorAll('form');
+  }
+
   forms.forEach(form => {
-    form.addEventListener('submit', (event) => {
+    if (form.dataset.sanitized) return;
+    form.dataset.sanitized = 'true';
+    form.addEventListener('submit', () => {
       const inputs = form.querySelectorAll('input, textarea, select');
       inputs.forEach(input => {
         if (input.type === 'file' || input.type === 'password') {


### PR DESCRIPTION
## Summary
- ensure dynamic form modals get sanitized before submission
- update `sanitizeForms` to accept a target form and prevent duplicate listeners

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eae527ebc832b85e1800e9f963338