### PR TITLE
Move draggable import outside modal loader

### DIFF
--- a/components/modals/draggable.js
+++ b/components/modals/draggable.js
@@ -1,26 +1,35 @@
-// Make modals draggable
-const modals = document.querySelectorAll('.ops-modal');
+// Initialize draggable behavior for any .ops-modal elements
+export function initDraggable(container = document) {
+  const modals = container.querySelectorAll('.ops-modal');
+  modals.forEach(modal => {
+    if (modal.dataset.draggableInitialized) return;
+    const header = modal.querySelector('.modal-header');
+    if (!header) return;
 
-modals.forEach(modal => {
-  const header = modal.querySelector('.modal-header');
-  let isDragging = false;
-  let offsetX, offsetY;
+    let isDragging = false;
+    let offsetX, offsetY;
 
-  header.addEventListener('mousedown', (e) => {
-    isDragging = true;
-    offsetX = e.clientX - modal.offsetLeft;
-    offsetY = e.clientY - modal.offsetTop;
-    modal.style.cursor = 'grabbing';
+    header.addEventListener('mousedown', (e) => {
+      isDragging = true;
+      offsetX = e.clientX - modal.offsetLeft;
+      offsetY = e.clientY - modal.offsetTop;
+      modal.style.cursor = 'grabbing';
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!isDragging) return;
+      modal.style.left = `${e.clientX - offsetX}px`;
+      modal.style.top = `${e.clientY - offsetY}px`;
+    });
+
+    document.addEventListener('mouseup', () => {
+      isDragging = false;
+      modal.style.cursor = 'grab';
+    });
+
+    modal.dataset.draggableInitialized = 'true';
   });
+}
 
-  document.addEventListener('mousemove', (e) => {
-    if (!isDragging) return;
-    modal.style.left = `${e.clientX - offsetX}px`;
-    modal.style.top = `${e.clientY - offsetY}px`;
-  });
-
-  document.addEventListener('mouseup', () => {
-    isDragging = false;
-    modal.style.cursor = 'grab';
-  });
-});
+// Automatically initialize any modals already on the page
+initDraggable();

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,13 @@
 import { sanitize } from './security.js';
 
+let draggableModulePromise;
+const loadDraggable = async () => {
+    if (!draggableModulePromise) {
+        draggableModulePromise = import('../components/modals/draggable.js');
+    }
+    return draggableModulePromise;
+};
+
 export function openModal(id) {
     const modal = document.getElementById(id);
     if (modal) {
@@ -36,7 +44,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const modal = modalElement.firstElementChild;
             modal.id = modalId;
             modalContainer.appendChild(modal);
-            await import('../components/modals/draggable.js');
+            const { initDraggable } = await loadDraggable();
+            initDraggable(modal);
             return modal;
         } catch (error) {
             console.error(`Failed to load modal: ${modalId}`, error);


### PR DESCRIPTION
## Summary
- load draggable.js only once in main.js
- export `initDraggable` from draggable.js and initialize newly added modals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687eae58034c832b94cf5a3c2b23d7fd