### PR TITLE
Use dynamic service modal loader

### DIFF
--- a/js/connector.js
+++ b/js/connector.js
@@ -46,3 +46,38 @@ function showFormModal(type) {
 window.addEventListener('toggle-lang', () => {
     lang = document.documentElement.lang;
 });
+
+export function openServiceModal(key) {
+    const root = document.getElementById('modal-container') ||
+                 document.getElementById('modal-root') || document.body;
+    const data = services[key];
+    if (!data) return;
+    const modalData = data[lang] || data['en'];
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay active';
+    overlay.innerHTML = `
+        <div class="ops-modal" role="dialog" aria-modal="true">
+          <button class="close-button" aria-label="Close">&times;</button>
+          <div class="modal-header">
+            <img src="${modalData.modal.img}" alt="${modalData.modal.imgAlt}">
+            <h3 class="modal-title">${modalData.modal.title}</h3>
+          </div>
+          <div class="modal-body">
+            <p>${modalData.modal.content}</p>
+            <ul class="modal-features">
+              ${modalData.modal.features.map(f=>`<li>${f}</li>`).join('')}
+            </ul>
+          </div>
+          <div class="modal-actions">
+            <a href="pages/contact.html" class="modal-btn cta">${lang === 'en' ? 'Contact Us' : 'Contáctenos'}</a>
+            <a href="pages/join.html" class="modal-btn primary">${lang === 'en' ? 'Join Us' : 'Únete'}</a>
+            <a href="pages/${modalData.modal.learn}" class="modal-btn">${lang === 'en' ? 'Learn More' : 'Aprender más'}</a>
+            <button class="modal-btn" onclick="openChatbot()">${lang === 'en' ? 'Ask Chattia' : 'Preguntar a Chattia'}</button>
+          </div>
+        </div>`;
+    root.appendChild(overlay);
+    makeModalDraggable(overlay.querySelector('.ops-modal'), overlay.querySelector('.modal-header'));
+    const close = () => overlay.remove();
+    overlay.querySelector('.close-button').onclick = close;
+    overlay.onclick = e => { if (e.target === overlay) close(); };
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,12 +1,4 @@
-import { sanitize } from './security.js';
-
-let draggableModulePromise;
-const loadDraggable = async () => {
-    if (!draggableModulePromise) {
-        draggableModulePromise = import('../components/modals/draggable.js');
-    }
-    return draggableModulePromise;
-};
+import { openServiceModal } from './connector.js';
 
 export function openModal(id) {
     const modal = document.getElementById(id);
@@ -25,53 +17,18 @@ export function closeModal(id) {
 window.openModal = openModal;
 
 document.addEventListener('DOMContentLoaded', () => {
-    const modalContainer = document.getElementById('modal-container');
     const cards = document.querySelectorAll('.card');
-
-    const modals = {
-        'business-modal': 'components/modals/business-modal.html',
-        'contactcenter-modal': 'components/modals/contactcenter-modal.html',
-        'itsupport-modal': 'components/modals/itsupport-modal.html',
-        'professionals-modal': 'components/modals/professionals-modal.html'
-    };
-
-    const loadModal = async (modalId, url) => {
-        try {
-            const response = await fetch(url);
-            const html = sanitize(await response.text());
-            const modalElement = document.createElement('div');
-            modalElement.innerHTML = html;
-            const modal = modalElement.firstElementChild;
-            modal.id = modalId;
-            modalContainer.appendChild(modal);
-            const { initDraggable } = await loadDraggable();
-            initDraggable(modal);
-            return modal;
-        } catch (error) {
-            console.error(`Failed to load modal: ${modalId}`, error);
-            return null;
-        }
+    const mapping = {
+        'business-modal': 'ops',
+        'contactcenter-modal': 'cc',
+        'itsupport-modal': 'it',
+        'professionals-modal': 'pro'
     };
 
     cards.forEach(card => {
-        const modalId = card.getAttribute('data-modal-target');
-        if (modalId && modals[modalId]) {
-            loadModal(modalId, modals[modalId]).then(modal => {
-                if (modal) {
-                    card.addEventListener('click', () => openModal(modalId));
-                    const closeButton = modal.querySelector('.close-button');
-                    if (closeButton) {
-                        closeButton.addEventListener('click', () => closeModal(modalId));
-                    }
-                }
-            });
-        }
-    });
-
-    modalContainer.addEventListener('click', (e) => {
-        if (e.target === modalContainer) {
-            const active = modalContainer.querySelector('.modal-overlay.active');
-            if (active) closeModal(active.id);
+        const key = mapping[card.getAttribute('data-modal-target')];
+        if (key) {
+            card.addEventListener('click', () => openServiceModal(key));
         }
     });
 });


### PR DESCRIPTION
## Summary
- generate service modals dynamically with `openServiceModal`
- load service modal on card click and remove old fetch logic

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687ee505cf44832ba22ca7a2649afa81